### PR TITLE
feat(logger): add Grafana Loki integration via pino-loki

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
       "dependencies": {
         "amqplib": "^0.10.9",
         "pino": "^10.2.1",
+        "pino-loki": "^3.0.0",
         "pino-pretty": "^13.1.3"
+      },
+      "bin": {
+        "amqp-logger": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -4751,6 +4755,25 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-loki": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-loki/-/pino-loki-3.0.0.tgz",
+      "integrity": "sha512-9TyUW5syTjp2nT70QcijJtIWUzdYUj+olQ7+fWNfm1/HrDGEWt86Q4ACzClH6DM6GBwtQimRDgneNczP+p4ypA==",
+      "license": "MIT",
+      "dependencies": {
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.3"
+      },
+      "bin": {
+        "pino-loki": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Julien-R44"
       }
     },
     "node_modules/pino-pretty": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "amqplib": "^0.10.9",
     "pino": "^10.2.1",
+    "pino-loki": "^3.0.0",
     "pino-pretty": "^13.1.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export function createComponents(env?: Record<string, string | undefined>): Serv
   const logger = createLogger({
     level: config.logLevel,
     pretty: process.env.NODE_ENV !== 'production',
+    loki: config.loki,
   });
 
   const connectionManager = new ConnectionManager({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,15 @@ import type { Channel } from 'amqplib';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+export interface LokiConfig {
+  host: string;
+  basicAuth?: {
+    username: string;
+    password: string;
+  };
+  labels?: Record<string, string>;
+}
+
 export interface AppConfig {
   rabbitmqUrl: string;
   queueName: string;
@@ -13,6 +22,7 @@ export interface AppConfig {
   reconnectAttempts: number;
   reconnectDelayMs: number;
   prefetchCount: number;
+  loki?: LokiConfig;
 }
 
 export interface ILogger {


### PR DESCRIPTION
## Summary

Add support for pushing logs to Grafana Loki for centralized log visualization.

### New Environment Variables
- `LOKI_HOST`: Loki server URL (e.g., `http://localhost:3100`)
- `LOKI_USERNAME` / `LOKI_PASSWORD`: Optional basic auth credentials
- `LOKI_LABELS`: Optional comma-separated labels (e.g., `app=logger,env=prod`)

### Changes
- Added `pino-loki` dependency for Loki transport
- Updated `Config` class to parse Loki environment variables
- Updated logger to support multiple transport targets (console + Loki)
- Added comprehensive tests for all new functionality

### Usage

```bash
RABBITMQ_URL=amqp://localhost:5672 \
QUEUE_NAME=my-queue \
LOKI_HOST=http://localhost:3100 \
LOKI_LABELS=app=amqp-logger,env=production \
npm start
```

When `LOKI_HOST` is configured, logs are sent to both console (if pretty mode) and Loki simultaneously.

---
🤖 Generated with [Claude Code](https://claude.ai/code)